### PR TITLE
test: deflake response fuzz request construction

### DIFF
--- a/internal/http/response/response_test.go
+++ b/internal/http/response/response_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -184,7 +185,13 @@ func FuzzErrorContentNegotiationAndEnvelope(f *testing.F) {
 			status += 100
 		}
 
-		req := httptest.NewRequest(http.MethodGet, path, nil)
+		// Avoid exercising URL parsing in this target; we only need header/path
+		// semantics for response formatting and content negotiation.
+		req := &http.Request{
+			Method: http.MethodGet,
+			Header: make(http.Header),
+			URL:    &url.URL{Path: path},
+		}
 		req.Header.Set("Accept", accept)
 		req.Header.Set("X-Request-Id", "fuzz-req")
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- replace `httptest.NewRequest` in `FuzzErrorContentNegotiationAndEnvelope` with direct `http.Request` construction
- keep the same content-negotiation and payload assertions while avoiding URL parsing overhead in the fuzz hot path

## Why
Nightly workflow `fuzz-nightly` failed in run https://github.com/sandeepkv93/everything-backend-starter-kit/actions/runs/22168321752 with:
- `FuzzErrorContentNegotiationAndEnvelope`
- `context deadline exceeded` after the 60s fuzz window

This change removes request URL parsing from the target under fuzzed inputs, reducing timeout flakiness without reducing response-behavior coverage.

## Validation
- `GOMAXPROCS=4 go test ./internal/http/response -run=^$ -fuzz=FuzzErrorContentNegotiationAndEnvelope -fuzztime=60s`
- `FUZZ_LONG_TIME=5s bash scripts/ci/run_fuzz_long.sh`
